### PR TITLE
Enables focus on window click

### DIFF
--- a/layout/includes.js
+++ b/layout/includes.js
@@ -1,13 +1,14 @@
 /**
  * Following Javascript is for functionalities and
  * any eventual animation for the console.
- * 
+ *
  * @author PatricNox <eronoxsmail@gmail.com>
  */
 
  /** Input Field  **/
 
     // Expand input width as user types
+    const input = document.querySelector('#cmd');
     let $i = 2;
     document.addEventListener('input', function (e) {
         $i++;
@@ -19,9 +20,16 @@
     // and endless potentional width it can have after
     // a longer usage of the field.
     document.addEventListener('keyDown', function (e) {
-        const input = document.querySelector('#cmd');
         input.style.width = "auto";
         $i = 2;
-    }, false)
+    }, false);
+
+    // Focus input field on document click.
+    // Don't focus when selection is not empty.
+    document.addEventListener('click', function (e) {
+        if (window.getSelection().toString() === '') {
+            input.focus();
+        }
+    }, false);
 
  /** End of Input Field **/


### PR DESCRIPTION
Adds an event listener on window click, when click has no selection (copy still available) it will focus on input.