### PR TITLE
Adds the option to disable sudo and logs the error without executing.

### DIFF
--- a/commands/log.php
+++ b/commands/log.php
@@ -36,8 +36,10 @@
          if (strlen($inputquery ) < 2)
             return;
 
-        // Execute command
-        $exec = shell_exec($inputquery.' 2>&1');
+        if (!ALLOW_SUDO && strpos($inputquery, 'sudo') !== false)
+            $exec = 'Error, sudo is not allowed!'; // Don't allow sudo
+        else
+            $exec = shell_exec($inputquery.' 2>&1'); // Execute command
 
         // Go back to root & save output
         chdir($rootPath);

--- a/index.php
+++ b/index.php
@@ -8,6 +8,7 @@
  * 
  * @author PatricNox <eronoxsmail@gmail.com>
  */
+const ALLOW_SUDO = true;
 
     session_start();
     $root = getcwd();


### PR DESCRIPTION
* Adds constant `ALLOW_SUDO` default now is `true`. But i will prefer `false`, but that's how it is now.
* Adds check on `ALLOW_SUDO` and if `sudo` is in the inputquery. If so it will set the error in the exec else the shell_exec will be executed.

https://github.com/PatricNox/Website-Terminal/issues/2