### PR TITLE
Change from file_get_contents to fopen for logs.txt

### DIFF
--- a/index.php
+++ b/index.php
@@ -27,5 +27,5 @@
     }
 
     ## Generate markup & style
-    $output = file_get_contents('logs.txt');
+    $output = fopen('logs.txt', 'w');
     include('./layout/markup.php');


### PR DESCRIPTION
If the file doesn't exists, file_get_contents throws an error, but with fopen if the file doesn't exists, then, we create it first and then read the content from it, but if the file exists, we just read it.

